### PR TITLE
fix: `vim.g.colors_name` not updated appropriately

### DIFF
--- a/lua/tinted-colorscheme.lua
+++ b/lua/tinted-colorscheme.lua
@@ -290,7 +290,7 @@ function M.setup(colors, config)
         )
     end
 
-    require("tinted-highlighter").set_highlights(colors_to_use, scheme_name, true, M.config.highlights)
+    require("tinted-highlighter").set_highlights(colors_to_use, scheme_name, false, M.config.highlights)
 end
 
 function M.available_colorschemes()


### PR DESCRIPTION
Fixes https://github.com/tinted-theming/tinted-nvim/issues/19

All `colors/*.vim` sets `g:colors_name` correctly after clearing highlights, but `hi clear` is called again in `tinted-highlighter.set_highlights`, despite not having enough context to determine the name of the colorscheme (it is only provided the color-table).

Ultimately, this is caused by a broken function call. We should either:

1. Pass along the theme name to `tinted-highlighter`, always, or
2. Tell it to not clear the highlights when passing in just a color-table.

There is already a parameter to control (2). This PR fixes the issue by passing in the correct value. There is already code to handle cases where a colorscheme name is provided, which will always induce `hi clear`, despite the param value.

This function needs to be cleaned up a bit, but for now this fixes the issue as reported while maintaining backwards compatibility.