### PR TITLE
fix(lualine): change C section to use a.foreground as foreground color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix merge
 - Remove old help docs file
+- Change lualine section C highlight to use foreground color
 
 ## [1.0.0] - 2026-02-14
 

--- a/lua/tinted-nvim/highlights/lualine.lua
+++ b/lua/tinted-nvim/highlights/lualine.lua
@@ -18,7 +18,7 @@ function M.build(_palette, aliases, _cfg)
 
     hl.LualineVisualA = { fg = a.background, bg = a.yellow, bold = true }
     hl.LualineVisualB = { fg = a.foreground, bg = a.dark_grey }
-    hl.LualineVisualC = { fg = a.background, bg = a.darkest_grey }
+    hl.LualineVisualC = { fg = a.foreground, bg = a.darkest_grey }
 
     hl.LualineReplaceA = { fg = a.background, bg = a.red, bold = true }
     hl.LualineReplaceB = { fg = a.foreground, bg = a.dark_grey }
@@ -26,7 +26,7 @@ function M.build(_palette, aliases, _cfg)
 
     hl.LualineCommandA = { fg = a.background, bg = a.green, bold = true }
     hl.LualineCommandB = { fg = a.foreground, bg = a.dark_grey }
-    hl.LualineCommandC = { fg = a.background, bg = a.darkest_grey }
+    hl.LualineCommandC = { fg = a.foreground, bg = a.darkest_grey }
 
     hl.LualineInactiveA = { fg = a.grey, bg = a.darkest_grey, bold = true }
     hl.LualineInactiveB = { fg = a.grey, bg = a.darkest_grey }


### PR DESCRIPTION
## Summary
The visual and command modes for C section of lualine uses `{ fg = a.background, bg = a.darkest_grey }`, which is almost hard to see actual content inside the dark themes and some of the light themes. I change it to use `a.foreground` instead of `a.background`.

Example of dark theme before fix (base16-tomorrow-night):
<img width="538" height="40" alt="base16-tomorrow-night (before)" src="https://github.com/user-attachments/assets/b2ce8a56-d92d-4bbb-ad70-f27f0abe0112" />
Example of light theme before fix (base16-tomorrow):
<img width="530" height="33" alt="base16-tomorrow (before)" src="https://github.com/user-attachments/assets/6380553b-0a4c-4c35-a0fb-bdd482cad028" />
Example of dark theme before fix (base24-tokyo-night-dark):
<img width="541" height="35" alt="base24-tokyo-night-dark (before)" src="https://github.com/user-attachments/assets/03c59abc-0482-400b-b5bb-2b313fcb403f" />
Example of light theme before fix (base24-tokyo-night-light):
<img width="529" height="34" alt="base24-tokyo-night-light (before)" src="https://github.com/user-attachments/assets/fec5d08c-ee0d-43db-a0bc-abd186e5a599" />

Example of dark theme after fix (base16-tomorrow-night):
<img width="819" height="32" alt="base16-tomorrow-night (after)" src="https://github.com/user-attachments/assets/999a7c01-c82f-4059-901a-344ce9fa6064" />
Example of light theme after fix (base16-tomorrow):
<img width="822" height="33" alt="base16-tomorrow (after)" src="https://github.com/user-attachments/assets/fc7deb6f-36ef-4967-8c5e-f01ccb44afc7" />
Example of dark theme after fix (base24-tokyo-night-dark):
<img width="819" height="32" alt="base24-tokyo-night-dark (after)" src="https://github.com/user-attachments/assets/264fa34f-dae4-4210-8ac9-1b091d16b071" />
Example of light theme after fix (base24-tokyo-night-light):
<img width="817" height="33" alt="base24-tokyo-night-light (after)" src="https://github.com/user-attachments/assets/81fdf933-cf6d-415c-a26b-0e0082065e53" />

## Checklist

- [x] I have **not** included the generated files `lua/tinted-nvim/palettes/*.lua`, `colors/*.vim` or `docs/tinted-nvim.txt`
- [x] I have run `just fmt` to format my code
- [ ] I have run `just lint` and fixed any issues
- [ ] I have run `just test` and all tests pass
- [x] I have updated CHANGELOG.md (if applicable)
- [x] I have added this change under the [Unreleased] section in CHANGELOG.md

## Test plan
We don't have built-in lualine tests yet. I have only tested with visual confirmation. If you have enabled the cache, remember to clean cache and restart Neovim.

I didn't run lint because changing background to foreground is not affecting lint result. (I'm a little lazy to install new tools 😅)