### PR TITLE
feat(background): set `vim.o.background` to `variant` in palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- **Background**: Automatically set `vim.o.background` to `variant` in palettes
+
 ### Fixed
 
 - Fix merge

--- a/lua/tinted-nvim/init.lua
+++ b/lua/tinted-nvim/init.lua
@@ -119,6 +119,7 @@ function M.load(scheme_name, opts)
             vim.o.termguicolors = true
         end
         vim.g.colors_name = name
+        vim.o.background = palette.variant
         public_state.scheme = name
         public_state.palette = palette
         public_state.palette_aliases = aliases.build(palette)
@@ -155,6 +156,7 @@ function M.load(scheme_name, opts)
     -- apply highlights and terminal colors
     highlights.apply(hl_defs, term)
     terminal.apply(term)
+    vim.o.background = palette.variant
 
     -- commit runtimepublic_state
     public_state.scheme = name

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -110,6 +110,24 @@ describe("init", function()
             assert.is_true(vim.o.termguicolors)
         end)
 
+        it("sets background (light)", function()
+            vim.o.background = "dark"
+
+            tinted.setup({ apply_scheme_on_startup = false })
+            tinted.load("base16-ayu-light")
+
+            assert.equal("light", vim.o.background)
+        end)
+
+        it("sets background (dark)", function()
+            vim.o.background = "light"
+
+            tinted.setup({ apply_scheme_on_startup = false })
+            tinted.load("base16-ayu-dark")
+
+            assert.equal("dark", vim.o.background)
+        end)
+
         it("clears existing highlights", function()
             vim.g.colors_name = "old-scheme"
 


### PR DESCRIPTION
## Summary
Vim's [`background`](https://neovim.io/doc/user/options/#'background') option is used to inform the colorscheme to adjust the color based on the value of `background`, which has two valid values, `dark` and `light`, just like `palette.variant`. Setting the `background` during load the colorscheme could help some plugins relied on it. For example, [codediff.nvim](https://github.com/esmuellert/codediff.nvim) adjust the color based on dark or light of the colorschemes.

## Checklist

- [x] I have **not** included the generated files `lua/tinted-nvim/palettes/*.lua`, `colors/*.vim` or `docs/tinted-nvim.txt`
- [x] I have run `just fmt` to format my code
- [x] I have run `just lint` and fixed any issues
- [x] I have run `just test` and all tests pass
- [x] I have updated CHANGELOG.md (if applicable)
- [x] I have added this change under the [Unreleased] section in CHANGELOG.md

## Test plan
Set `vim.o.background` to opposite value of the target colorscheme. Then load the colorscheme to check whether the `vim.o.background` is changed. The concept is identical to the test of `vim.o.termguicolors`. Both of `dark` and `light` are tested.
