### PR TITLE
feat(highlights): better contrast in snacks.nvim highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Fix merge
 - Remove old help docs file
 - Change lualine section C highlight to use foreground color
+- Fix low-contrast highlights from `snacks.nvim`
 
 ## [1.0.0] - 2026-02-14
 

--- a/lua/tinted-nvim/config.lua
+++ b/lua/tinted-nvim/config.lua
@@ -238,6 +238,7 @@ M.defaults = {
             blink = true,
             dapui = true,
             lualine = true,
+            snacks = true,
         },
         use_lazy_specs = true,
 

--- a/lua/tinted-nvim/highlights/init.lua
+++ b/lua/tinted-nvim/highlights/init.lua
@@ -24,6 +24,7 @@ local integrations = {
     blink = "tinted-nvim.highlights.blink",
     dapui = "tinted-nvim.highlights.dapui",
     lualine = "tinted-nvim.highlights.lualine",
+    snacks = "tinted-nvim.highlights.snacks",
 }
 
 -- Resolve a single color value.

--- a/lua/tinted-nvim/highlights/snacks.lua
+++ b/lua/tinted-nvim/highlights/snacks.lua
@@ -8,14 +8,14 @@ function M.build(_palette, aliases, _cfg)
     local a = aliases
     return {
         -- Dashboard
-        SnacksDashboardDir = { fg = a.blue },
+        SnacksDashboardDir = { link = "Directory" },
         SnacksDashboardFile = { fg = a.white, bold = true },
         SnacksDashboardDesc = { fg = a.white, bold = true },
 
         -- Picker
-        SnacksPickerDir = { fg = a.blue },
+        SnacksPickerDir = { link = "Directory" },
         SnacksPickerFile = { link = "Normal" },
-        SnacksPickerMatch = { fg = a.bright_blue, bold = true },
+        SnacksPickerMatch = { link = "IncSearch" },
     }
 end
 

--- a/lua/tinted-nvim/highlights/snacks.lua
+++ b/lua/tinted-nvim/highlights/snacks.lua
@@ -1,0 +1,22 @@
+local M = {}
+
+---@param _palette tinted-nvim.Palette
+---@param aliases table<string, string>
+---@param _cfg tinted-nvim.Config
+---@return tinted-nvim.Highlights
+function M.build(_palette, aliases, _cfg)
+    local a = aliases
+    return {
+        -- Dashboard
+        SnacksDashboardDir = { fg = a.blue },
+        SnacksDashboardFile = { fg = a.white, bold = true },
+        SnacksDashboardDesc = { fg = a.white, bold = true },
+
+        -- Picker
+        SnacksPickerDir = { fg = a.blue },
+        SnacksPickerFile = { link = "Normal" },
+        SnacksPickerMatch = { fg = a.bright_blue, bold = true },
+    }
+end
+
+return M


### PR DESCRIPTION
## Summary

Some [snacks.nvim](https://github.com/folke/snacks.nvim) highlights is too low contrast out-of-the-box.

### Before

<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 42 31@2x" src="https://github.com/user-attachments/assets/5e41d01a-2c0f-47a5-b46d-8e16b20b2bf3" />
<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 42 15@2x" src="https://github.com/user-attachments/assets/92372f1b-3185-4fa2-8da1-548dc55bf543" />
<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 43 06@2x" src="https://github.com/user-attachments/assets/616fc1d8-bb4d-4dc5-934f-d72dd24f3a21" />
<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 43 43@2x" src="https://github.com/user-attachments/assets/97a0bd97-9c6c-4d78-b537-c010f1aa0156" />


### After

<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 39 30@2x" src="https://github.com/user-attachments/assets/fbe960ba-a7c5-40fb-ad13-205c27e7a0f9" />
<img width="2646" height="2908" alt="CleanShot 2026-05-31 at 19 40 06@2x" src="https://github.com/user-attachments/assets/81c016bd-911e-49a8-98e6-6216f144dbdf" />
<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 41 07@2x" src="https://github.com/user-attachments/assets/a28a03c6-0d20-4fc2-9157-19cbbf7f6866" />
<img width="2654" height="2916" alt="CleanShot 2026-05-31 at 19 44 12@2x" src="https://github.com/user-attachments/assets/e5318b22-46ee-4c3f-9300-39f5fb90abd4" />


## Checklist

- [x] I have **not** included the generated files `lua/tinted-nvim/palettes/*.lua`, `colors/*.vim` or `docs/tinted-nvim.txt`
- [x] I have run `just fmt` to format my code
- [x] I have run `just lint` and fixed any issues
- [x] I have run `just test` and all tests pass
- [x] I have updated CHANGELOG.md (if applicable)
- [x] I have added this change under the [Unreleased] section in CHANGELOG.md

## Test plan

<!-- How did you test your changes? -->
