### PR TITLE
feat(highlights): preserve syntax highlighting foreground colors on diff lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - **Background**: Automatically set `vim.o.background` to `variant` in palettes
+- **Diff**: Preserve foreground values e.g. syntax highlighting
 
 ### Fixed
 

--- a/lua/tinted-nvim/highlights/core.lua
+++ b/lua/tinted-nvim/highlights/core.lua
@@ -128,12 +128,25 @@ function M.build(palette, _aliases, cfg)
     }
 
     hl.DiffAdd = {
-        fg = ui.global.background.normal,
-        bg = { darken = pal.blue.normal, amount = 0.4 },
+        bg = { darken = pal.green.normal, amount = 0.75 },
     }
-    hl.DiffText = { link = "DiffAdd" }
-    hl.DiffChange = { link = "Cursorline" }
-    hl.DiffDelete = { link = "NonText" }
+    hl.DiffText = {
+        bg = { darken = pal.blue.normal, amount = 0.75 },
+    }
+
+    hl.DiffChange = {
+        bg = { darken = ui.highlight.line.background, amount = 0.5 },
+    }
+    hl.DiffDelete = {
+        bg = { darken = pal.red.normal, amount = 0.9 },
+        fg = pal.gray.dim,
+    }
+
+    if vim.fn.has("nvim-0.12.0") == 1 then
+        hl.DiffTextAdd = {
+            link = "DiffAdd",
+        }
+    end
 
     hl.MsgArea = { fg = ui.global.foreground.normal }
     hl.MsgSeparator = { fg = pal.gray.bright }

--- a/lua/tinted-nvim/highlights/core.lua
+++ b/lua/tinted-nvim/highlights/core.lua
@@ -135,7 +135,7 @@ function M.build(palette, _aliases, cfg)
     }
 
     hl.DiffChange = {
-        bg = ui.highlight.line.background
+        bg = ui.highlight.line.background,
     }
     hl.DiffDelete = {
         bg = { darken = pal.red.normal, amount = 0.9 },

--- a/lua/tinted-nvim/highlights/core.lua
+++ b/lua/tinted-nvim/highlights/core.lua
@@ -135,7 +135,7 @@ function M.build(palette, _aliases, cfg)
     }
 
     hl.DiffChange = {
-        bg = { darken = ui.highlight.line.background, amount = 0.5 },
+        bg = ui.highlight.line.background
     }
     hl.DiffDelete = {
         bg = { darken = pal.red.normal, amount = 0.9 },


### PR DESCRIPTION
## Summary

The `Diff*` highlights define their own `fg` values, which clobber the `fg` values for syntax highlights.

This PR limits the `Diff*` highlights to just `bg` values, and using `green/red` for line diffs, and `blue` for inline/word modifications.

It also defines the `DiffTextAdd` highlight group that is added in Neovim 0.12, treating inline/word additions distinctly from inline/word changes (`green` vs `blue`)

### Before

<img width="3324" height="2696" alt="CleanShot 2026-06-02 at 20 41 59@2x" src="https://github.com/user-attachments/assets/60b1d0de-d0cd-4775-bcec-25d96a223a08" />
<img width="3324" height="2696" alt="CleanShot 2026-06-02 at 20 42 11@2x" src="https://github.com/user-attachments/assets/be13c948-2009-4691-9234-38f8c9a525f4" />

### After

<img width="3324" height="2696" alt="CleanShot 2026-06-02 at 20 41 45@2x" src="https://github.com/user-attachments/assets/2999034d-4871-4a50-8c08-c80bd0c8d0eb" />
<img width="3324" height="2696" alt="CleanShot 2026-06-02 at 20 44 16@2x" src="https://github.com/user-attachments/assets/955be00e-d336-4a62-9f4f-2651dadb62d2" />



## Checklist

- [x] I have **not** included the generated files `lua/tinted-nvim/palettes/*.lua`, `colors/*.vim` or `docs/tinted-nvim.txt`
- [x] I have run `just fmt` to format my code
- [x] I have run `just lint` and fixed any issues
- [x] I have run `just test` and all tests pass
- [x] I have updated CHANGELOG.md (if applicable)
- [x] I have added this change under the [Unreleased] section in CHANGELOG.md

## Test plan

<!-- How did you test your changes? -->
