### PR TITLE
doc(readme): add lualine integration steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,24 @@ require("tinted-nvim").setup({
 - `require("tinted-nvim").get_palette()` - returns the current Base16/Base24 palette.
 - `require("tinted-nvim").get_palette_aliases()` - returns the palette using color aliases.
 
+## Integrations
+
+### `lualine.nvim`
+
+Aside from setting `highlights.integration.lualine` to `true` in this plugin's setup, you'll also need to set lualine's
+theme to `"tinted"` i.e.:
+
+```lua
+
+require("lualine").setup({
+    options = {
+        theme = "tinted"
+    }
+})
+
+```
+
+
 ## Troubleshooting
 
 - Truecolor support: this plugin is optimized for truecolor terminals. If you
@@ -394,3 +412,4 @@ See [LICENSE].
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 [CONTRIBUTING.md]: https://github.com/tinted-theming/home/blob/main/CONTRIBUTING.md
 [LICENSE]: ./LICENSE
+


### PR DESCRIPTION
## Summary

Update README with instructions on how to set lualine's theme so it integrates with `tinted-nvim` properly.

## Checklist

- [x] I have **not** included the generated files `lua/tinted-nvim/palettes/*.lua`, `colors/*.vim` or `docs/tinted-nvim.txt`
- [x] I have run `just fmt` to format my code
- [x] I have run `just lint` and fixed any issues
- [x] I have run `just test` and all tests pass
- [x] I have updated CHANGELOG.md (if applicable)
- [x] I have added this change under the [Unreleased] section in CHANGELOG.md

## Test plan

<!-- How did you test your changes? -->
